### PR TITLE
Add support for targeting player with !gpb command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 SourceMod plugin that lets GOKZ or KZTimer players request their personal best times from the Global API.
 
 ### Commands
-- **!gpb / !globalpb**  -  Displays the main course PB
-- **!gbpb / !globalbonuspb**  -  Displays the bonus course PB
+- **!gpb / !globalpb**  -  Displays the main course PB. Usage: `!gpb <mapname> <playername>`.
+- **!gbpb / !globalbonuspb**  -  Displays the bonus course PB. Usage: `!gbpb <bonus number>`.
 
 ### Requirements
 - GOKZ


### PR DESCRIPTION
Adding another parameter for the functions that requests the global pb,
to allow separation of the calling client, and possibly a targeted
player. This allows us to check the PB of other players that are
connected to the server at the moment. A next level version of this
would be to allow searching for any players, but that is probably way
too overkill. Being able to see the GPB for connected players helps a
lot already.

Another nice feature could be to check if the first argument is a map or
a client, and basically allow `!gpb <playername>`, but that might cause
confusion with command usage. So decided to keep it so that you have to
specify the mapname in case you want to target another player.

The FindTarget function will ignore bots, so no need to check if the
targeted player is a valid client or not.

We need to load the translations for common, since the `FindTarget`
function will use it to output an error if it cannot find a client.

Implements #2 .