### PR TITLE
Update SteamWorks capitalization

### DIFF
--- a/addons/sourcemod/scripting/include/globalpb.inc
+++ b/addons/sourcemod/scripting/include/globalpb.inc
@@ -1,4 +1,4 @@
-#include <steamworks>
+#include <SteamWorks>
 
 stock const char gC_APIModes[3][] =
 {


### PR DESCRIPTION
\<steamworks\> will not properly find the file on Linux systems unless you make a copy with lowercase letters. Linux is capital specific.

If you look at the original include it's in capitals and therefore it's the standard way to reference it: https://github.com/KyleSanderson/SteamWorks/blob/master/Pawn/includes/SteamWorks.inc