### PR TITLE
Use HTTPS for GlobalAPI

### DIFF
--- a/addons/sourcemod/scripting/include/globalpb.inc
+++ b/addons/sourcemod/scripting/include/globalpb.inc
@@ -21,7 +21,7 @@ stock bool RequestGlobalPB(int client, const char[] map, int course, int mode, b
 
 	char link[512];
 	Format(link, sizeof(link), 
-		"http://kztimerglobal.com/api/v1.0/records/top?steam_id=%s&map_name=%s&stage=%d&modes_list_string=%s&has_teleports=%s&limit=1&tickrate=128", 
+		"https://kztimerglobal.com/api/v1.0/records/top?steam_id=%s&map_name=%s&stage=%d&modes_list_string=%s&has_teleports=%s&limit=1&tickrate=128", 
 		steamid, map, course, gC_APIModes[mode], teleports ? "true" : "false");
 
 	Handle request = SteamWorks_CreateHTTPRequest(k_EHTTPMethodGET, link);


### PR DESCRIPTION
**Due to some changes being made along with the LetsEncrypt DST Root CA X3 root certificate expiring, the GlobalAPI will no longer work over HTTP, it will instead redirect to HTTPS**.

And this combined with the fact that SteamWorks does not seem to or even have an option to follow redirects.
This means that any server using this plugin (prior to this commit) would not simply work.

This change simply just uses the HTTPS endpoint which causes no redirect, and should make it work again.

P.S. If you would like me to increment the version in this PR, let me know, I'm not sure if you have CI/CD setup on pushes to master.